### PR TITLE
Makes use of UUID format for `string` type

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -12,20 +12,24 @@ extra-source-files:
 - README.md
 ghc-options: -Wall
 
+default-extensions:
+ - OverloadedStrings
+ - NoImplicitPrelude
+
 dependencies:
-  - base >= 4.7 && < 5
-  - hedgehog
   - aeson
-  - protolude
+  - base >= 4.7 && < 5
   - bytestring
+  - containers
+  - exceptions
+  - hedgehog
   - lens
-  - vector
+  - protolude
+  - regex-genex
   - scientific
   - text
-  - containers
   - unordered-containers
-  - regex-genex
-  - exceptions
+  - vector
 
 library:
   source-dirs: src
@@ -41,4 +45,4 @@ tests:
     dependencies:
       - tasty
       - tasty-hedgehog
-      - regex-posix
+      - regex-pcre

--- a/src/Hedgehog/Gen/JSON/JSONSchema.hs
+++ b/src/Hedgehog/Gen/JSON/JSONSchema.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NoImplicitPrelude          #-}
-{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE StrictData                 #-}
 {-# LANGUAGE TemplateHaskell            #-}
 
@@ -83,6 +81,10 @@ newtype StringConstraintPattern = StringConstraintPattern
   { unStringConstraintPattern :: Text
   } deriving (Generic, Eq, Show, Aeson.FromJSON)
 
+newtype StringConstraintFormat = StringConstraintFormat
+  { unStringConstraintFormat :: Text
+  } deriving (Generic, Eq, Show, Aeson.FromJSON)
+
 newtype StringConstraintMaxLength = StringConstraintMaxLength
   { unStringConstraintMaxLength :: Int
   } deriving (Generic, Eq, Show, Aeson.FromJSON)
@@ -94,13 +96,13 @@ newtype StringConstraintMinLength = StringConstraintMinLength
 instance Aeson.FromJSON Schema where
   parseJSON =
     withObject "Schema" $ \obj ->
-      Schema <$> obj .:? "type" <*> obj .:? "enum" <*> obj .:? "const" <*> obj .:? "properties" <*> obj .:? "required" <*>
-      obj .:? "multipleOf" <*>
+      Schema <$> obj .:? "type" <*> obj .:? "enum" <*> obj .:? "const" <*> obj .:? "properties" <*> obj .:? "required" <*> obj .:? "multipleOf" <*>
       obj .:? "maximum" <*>
       obj .:? "exclusiveMaximum" <*>
       obj .:? "minimum" <*>
       obj .:? "exclusiveMinimum" <*>
       obj .:? "pattern" <*>
+      obj .:? "format" <*>
       obj .:? "maxLength" <*>
       obj .:? "minLength" <*>
       obj .:? "items" <*>
@@ -144,6 +146,7 @@ data Schema = Schema
   , _schemaMinimum          :: Maybe NumberConstraintMinimum
   , _schemaExclusiveMinimum :: Maybe NumberConstraintExclusiveMinimum
   , _schemaPattern          :: Maybe StringConstraintPattern
+  , _schemaFormat           :: Maybe StringConstraintFormat
   , _schemaMaxLength        :: Maybe StringConstraintMaxLength
   , _schemaMinLength        :: Maybe StringConstraintMinLength
   , _schemaItems            :: Maybe ArrayConstraintItems
@@ -155,24 +158,25 @@ data Schema = Schema
 emptySchema :: Schema
 emptySchema =
   Schema
-  { _schemaType = Nothing
-  , _schemaEnum = Nothing
-  , _schemaConst = Nothing
-  , _schemaRequired = Nothing
-  , _schemaProperties = Nothing
-  , _schemaMultipleOf = Nothing
-  , _schemaMaximum = Nothing
-  , _schemaMinimum = Nothing
-  , _schemaExclusiveMaximum = Nothing
-  , _schemaExclusiveMinimum = Nothing
-  , _schemaPattern = Nothing
-  , _schemaMinLength = Nothing
-  , _schemaMaxLength = Nothing
-  , _schemaItems = Nothing
-  , _schemaMinItems = Nothing
-  , _schemaMaxItems = Nothing
-  , _schemaUniqueItems = Nothing
-  }
+    { _schemaType = Nothing
+    , _schemaEnum = Nothing
+    , _schemaConst = Nothing
+    , _schemaRequired = Nothing
+    , _schemaProperties = Nothing
+    , _schemaMultipleOf = Nothing
+    , _schemaMaximum = Nothing
+    , _schemaMinimum = Nothing
+    , _schemaExclusiveMaximum = Nothing
+    , _schemaExclusiveMinimum = Nothing
+    , _schemaPattern = Nothing
+    , _schemaFormat = Nothing
+    , _schemaMinLength = Nothing
+    , _schemaMaxLength = Nothing
+    , _schemaItems = Nothing
+    , _schemaMinItems = Nothing
+    , _schemaMaxItems = Nothing
+    , _schemaUniqueItems = Nothing
+    }
 
 makeLenses ''Schema
 

--- a/src/Hedgehog/Gen/JSON/Ranges.hs
+++ b/src/Hedgehog/Gen/JSON/Ranges.hs
@@ -4,6 +4,7 @@ module Hedgehog.Gen.JSON.Ranges where
 
 import           Control.Lens
 import           Hedgehog
+import           Protolude
 
 newtype NumberRange = NumberRange
   { unNumberRange :: Range Double

--- a/src/Hedgehog/Gen/JSON/Unconstrained.hs
+++ b/src/Hedgehog/Gen/JSON/Unconstrained.hs
@@ -7,6 +7,7 @@ import qualified Data.Vector              as Vector
 import           Hedgehog
 import qualified Hedgehog.Gen             as Gen
 import           Hedgehog.Gen.JSON.Ranges
+import           Protolude
 
 genNull :: Gen A.Value
 genNull = pure A.Null
@@ -36,12 +37,4 @@ genObj ranges = A.object <$> Gen.list ar ((,) <$> Gen.text sr Gen.unicode <*> ge
     (ArrayRange ar) = ranges ^. arrayRange
 
 genValue :: Ranges -> Gen A.Value
-genValue ranges =
-  Gen.choice
-    [ genNull
-    , genStringValue (ranges ^. stringRange)
-    , genBool
-    , genNumber (ranges ^. numberRange)
-    , genArray ranges
-    , genObj ranges
-    ]
+genValue ranges = Gen.choice [genNull, genStringValue (ranges ^. stringRange), genBool, genNumber (ranges ^. numberRange), genArray ranges, genObj ranges]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.1
+resolver: lts-10.7
 
 packages:
 - .

--- a/test/Hedgehog/Gen/JSON/Constrained/Internal/InternalSpec.hs
+++ b/test/Hedgehog/Gen/JSON/Constrained/Internal/InternalSpec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Hedgehog.Gen.JSON.Constrained.Internal.InternalSpec
@@ -17,7 +15,7 @@ import qualified Hedgehog.Range                         as Range
 import           Protolude
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
-import           Text.Regex.Posix
+import           Text.Regex.PCRE
 
 prop_genBoundedInteger :: Property
 prop_genBoundedInteger =
@@ -84,12 +82,13 @@ prop_genStringFromRegexp =
     assert $ Text.unpack v =~ Text.unpack regexp
 
 prop_genUniqueItems :: Property
-prop_genUniqueItems = property $ do
-  let gen = Gen.int (Range.linear 0 1000)
-  generated <- forAll $ genUniqueItems (Range.linear 10 50) gen
-  assert $ length generated <= 50
-  assert $ length generated >= 10
-  (length . HashSet.fromList) generated === length generated
+prop_genUniqueItems =
+  property $ do
+    let gen = Gen.int (Range.linear 0 1000)
+    generated <- forAll $ genUniqueItems (Range.linear 10 50) gen
+    assert $ length generated <= 50
+    assert $ length generated >= 10
+    (length . HashSet.fromList) generated === length generated
 
 tests :: TestTree
 tests =


### PR DESCRIPTION
Falls back to using `format` for `string` types when no `pattern` is specified, before resorting lastly to generating unformatted strings.

Closes #5 