### PR TITLE
Makes use of `"date-time"` format of type `"string"`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -10,7 +10,7 @@ copyright:           2017 Amr Hassan
 category:            Test
 extra-source-files:
 - README.md
-ghc-options: -Wall
+ghc-options: -Wall -fhide-source-paths
 
 default-extensions:
  - OverloadedStrings
@@ -26,8 +26,11 @@ dependencies:
   - lens
   - protolude
   - regex-genex
+  - timerep
   - scientific
   - text
+  - time
+  - tz
   - unordered-containers
   - vector
 

--- a/src/Hedgehog/Gen/JSON/Constrained.hs
+++ b/src/Hedgehog/Gen/JSON/Constrained.hs
@@ -10,6 +10,7 @@ import           Control.Lens
 import qualified Data.Aeson                             as Aeson
 import qualified Data.HashMap.Strict                    as HashMap
 import qualified Data.Scientific                        as Scientific
+import           Data.Time.RFC3339
 import qualified Data.Vector                            as Vector
 import           Hedgehog
 import qualified Hedgehog.Gen                           as Gen
@@ -78,6 +79,8 @@ genStringValue (StringRange sr) schema =
         Nothing                         -> genUnformatted
   where
     genWithFormat "uuid" = Aeson.String <$> genStringFromRegexp "[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}"
+    genWithFormat "date-time" = (Aeson.String . formatTimeRFC3339) <$> genZonedTime (Range.linearFrac 0 999999999999999999)
+    genWithFormat "RFC 3339 date-time" = genWithFormat "date-time"
     genWithFormat _ = genUnformatted
     genUnformatted = Aeson.String <$> genBoundedString (schema ^. schemaMinLength) (schema ^. schemaMaxLength) sr
 


### PR DESCRIPTION
Closes #7 